### PR TITLE
vimc-7153 add CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
 __pycache__
-
+dist

--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ Options:
 
 Here `<path>` is the path to a directory that contains a configuration file `montagu.yml`.
 
+## Dev requirements
+
+1. [Python3](https://www.python.org/downloads/) (>= 3.7)
+2. [Hatch](https://hatch.pypa.io/latest/install/)
+
+## Test and lint
+
+1. `hatch run test`
+2. `hatch run lint:fmt`
+
+To get coverage reported locally in the console, use `hatch run cov`. 
+On CI, use `hatch run cov-ci` to generate an xml report.
+
+## Build
+
+```console
+hatch build
+```
+
+## Install from local sources
+
+1. `hatch build`
+2. `pip install dist/montagu_deploy-{version}.tar.gz`
+
+
 ## License
 
 `montagu-deploy` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ hatch build
 1. `hatch build`
 2. `pip install dist/montagu_deploy-{version}.tar.gz`
 
+## Publish to PyPi
+
+```console
+hatch publish
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,42 @@
 
 -----
 
-**Table of Contents**
-
-- [Installation](#installation)
-- [License](#license)
+This is the command-line tool for deploying Montagu. It is a [Hatch](https://hatch.pypa.io/latest/install/) project.
 
 ## Installation
 
 ```console
 pip install montagu-deploy
 ```
+
+## Usage
+
+```
+$ montagu --help
+Usage:
+  montagu --version
+  montagu start <path> [--extra=PATH] [--option=OPTION]... [--pull]
+  montagu status <path>
+  montagu stop <path> [--volumes] [--network] [--kill] [--force]
+    [--extra=PATH] [--option=OPTION]...
+
+Options:
+  --extra=PATH     Path, relative to <path>, of yml file of additional
+                   configuration
+  --option=OPTION  Additional configuration options, in the form key=value
+                   Use dots in key for hierarchical structure, e.g., a.b=value
+                   This argument may be repeated to provide multiple arguments
+  --pull           Pull images before starting
+  --volumes        Remove volumes (WARNING: irreversible data loss)
+  --network        Remove network
+  --kill           Kill the containers (faster, but possible db corruption)
+  --force          Force stop even if containers are corrupted and cannot
+                   signal their running configuration, or if config cannot be
+                   parsed. Use with extra and/or option to force stop with
+                   configuration options.
+```
+
+Here `<path>` is the path to a directory that contains a configuration file `montagu.yml`.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "constellation"
+  "constellation",
+  "docopt"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ Documentation = "https://github.com/unknown/montagu-deploy#readme"
 Issues = "https://github.com/unknown/montagu-deploy/issues"
 Source = "https://github.com/unknown/montagu-deploy"
 
+[project.scripts]
+montagu = "montagu_deploy.cli:main"
+
 [tool.hatch.version]
 path = "src/montagu_deploy/__about__.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ ban-relative-imports = "all"
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.coverage.run]
-source_pkgs = ["montagu_deploy", "tests"]
+source = ["src"]
 branch = true
 parallel = true
 omit = [

--- a/src/montagu_deploy/cli.py
+++ b/src/montagu_deploy/cli.py
@@ -1,0 +1,131 @@
+"""Usage:
+  montagu --version
+  montagu start <path> [--extra=PATH] [--option=OPTION]... [--pull]
+  montagu status <path>
+  montagu stop <path> [--volumes] [--network] [--kill] [--force]
+    [--extra=PATH] [--option=OPTION]...
+
+Options:
+  --extra=PATH     Path, relative to <path>, of yml file of additional
+                   configuration
+  --option=OPTION  Additional configuration options, in the form key=value
+                   Use dots in key for hierarchical structure, e.g., a.b=value
+                   This argument may be repeated to provide multiple arguments
+  --pull           Pull images before starting
+  --volumes        Remove volumes (WARNING: irreversible data loss)
+  --network        Remove network
+  --kill           Kill the containers (faster, but possible db corruption)
+  --force          Force stop even if containers are corrupted and cannot
+                   signal their running configuration, or if config cannot be
+                   parsed. Use with extra and/or option to force stop with
+                   configuration options.
+"""
+
+import docopt
+import yaml
+
+import montagu_deploy.__about__ as about
+from montagu_deploy.config import MontaguConfig
+from montagu_deploy.montagu_constellation import MontaguConstellation
+
+
+def main(argv=None):
+    path, extra, options, args = parse_args(argv)
+    if args.version:
+        return about.__version__
+    else:
+        cfg = MontaguConfig(path, extra, options)
+        obj = MontaguConstellation(cfg)
+        if args.action == "start":
+            montagu_start(obj, args)
+        elif args.action == "status":
+            montagu_status(obj)
+        elif args.action == "stop":
+            montagu_stop(obj, args, cfg)
+        return True
+
+
+def parse_args(argv=None):
+    opts = docopt.docopt(__doc__, argv)
+    path = opts["<path>"]
+    extra = opts["--extra"]
+    options = parse_option(opts)
+    return path, extra, options, MontaguArgs(opts)
+
+
+def montagu_start(obj, args):
+    obj.start(pull_images=args.pull)
+
+
+def montagu_status(obj):
+    obj.status()
+
+
+def montagu_stop(obj, args, cfg):
+    if args.volumes:
+        verify_data_loss(cfg)
+    obj.stop(kill=args.kill, remove_network=args.network, remove_volumes=args.volumes)
+
+
+def verify_data_loss(cfg):
+    if cfg.protect_data:
+        err = "Cannot remove volumes with this configuration"
+        raise Exception(err)
+    else:
+        print(
+            """WARNING! PROBABLE IRREVERSIBLE DATA LOSS!
+You are about to delete the data volumes. This action cannot be undone
+and will result in the irreversible loss of *all* data associated with
+the application. This includes all databases, packet data etc."""
+        )
+    if not prompt_yes_no():
+        msg = "Not continuing"
+        raise Exception(msg)
+
+
+def prompt_yes_no(get_input=input):
+    return get_input("\nContinue? [yes/no] ") == "yes"
+
+
+def parse_option(args):
+    return [string_to_dict(x) for x in args["--option"]]
+
+
+def string_to_dict(string):
+    """Convert a configuration option a.b.c=x to a dictionary
+    {"a": {"b": "c": x}}"""
+    # Won't deal with dots embedded within quotes but that's ok as
+    # that should not be allowed generally.
+    try:
+        key, value = string.split("=")
+    except ValueError as err:
+        msg = f"Invalid option '{string}', expected option in form key=value"
+        raise Exception(msg) from err
+    value = yaml_atom_parse(value)
+    for k in reversed(key.split(".")):
+        value = {k: value}
+    return value
+
+
+def yaml_atom_parse(x):
+    ret = yaml.safe_load(x)
+    if type(ret) not in [bool, int, float, str]:
+        msg = f"Invalid value '{x}' - expected simple type"
+        raise Exception(msg)
+    return ret
+
+
+class MontaguArgs:
+    def __init__(self, args):
+        if args["start"]:
+            self.action = "start"
+        elif args["status"]:
+            self.action = "status"
+        elif args["stop"]:
+            self.action = "stop"
+
+        self.pull = args["--pull"]
+        self.kill = args["--kill"]
+        self.volumes = args["--volumes"]
+        self.network = args["--network"]
+        self.version = args["--version"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,138 @@
+import io
+from contextlib import redirect_stdout
+from unittest import mock
+
+import pytest
+
+from src.montagu_deploy import cli
+from src.montagu_deploy.cli import prompt_yes_no, verify_data_loss
+from src.montagu_deploy.config import MontaguConfig
+
+
+def test_parse_args():
+    res = cli.parse_args(["start", "config/basic", "--pull"])
+    assert res[0] == "config/basic"
+    assert res[1] is None
+    assert res[2] == []
+    args = res[3]
+    assert args.action == "start"
+    assert args.pull is True
+    assert args.kill is False
+    assert args.volumes is False
+    assert args.network is False
+
+    res = cli.parse_args(["start", "config/basic", "--extra=extra.yml"])
+    assert res[1] == "extra.yml"
+
+    res = cli.parse_args(["start", "config/basic", "--option=a=x", "--option=b.c=y"])
+    assert res[2] == [{"a": "x"}, {"b": {"c": "y"}}]
+
+    res = cli.parse_args(["stop", "config/basic", "--kill", "--network", "--volumes"])
+    args = res[3]
+    assert args.action == "stop"
+    assert args.pull is False
+    assert args.kill is True
+    assert args.volumes is True
+    assert args.network is True
+
+    res = cli.parse_args(["status", "config/basic"])
+    args = res[3]
+    assert args.action == "status"
+
+    res = cli.parse_args(["--version"])
+    args = res[3]
+    assert args.version is True
+
+
+def test_version():
+    res = cli.main(["--version"])
+    assert res == "0.0.1"
+
+
+def test_args_passed_to_start():
+    with mock.patch("src.montagu_deploy.cli.montagu_start") as f:
+        cli.main(["start", "config/basic"])
+
+    assert f.called
+    assert f.call_args[0][1].pull is False
+
+    with mock.patch("src.montagu_deploy.cli.montagu_start") as f:
+        cli.main(["start", "config/basic", "--pull"])
+
+    assert f.called
+    assert f.call_args[0][1].pull is True
+
+
+def test_args_passed_to_stop():
+    with mock.patch("src.montagu_deploy.cli.montagu_stop") as f:
+        cli.main(["stop", "config/basic"])
+
+    assert f.called
+    assert f.call_args[0][1].kill is False
+    assert f.call_args[0][1].network is False
+    assert f.call_args[0][1].volumes is False
+
+    with mock.patch("src.montagu_deploy.cli.montagu_stop") as f:
+        cli.main(["stop", "config/basic", "--volumes", "--network"])
+
+    assert f.called
+    assert f.call_args[0][1].kill is False
+    assert f.call_args[0][1].network is True
+    assert f.call_args[0][1].volumes is True
+
+
+def test_verify_data_loss_called():
+    f = io.StringIO()
+    with redirect_stdout(f):
+        with mock.patch("src.montagu_deploy.cli.verify_data_loss") as verify:
+            verify.return_value = True
+            cli.main(["stop", "config/basic", "--volumes"])
+
+    assert verify.called
+
+
+def test_verify_data_loss_not_called():
+    f = io.StringIO()
+    with redirect_stdout(f):
+        with mock.patch("src.montagu_deploy.cli.verify_data_loss") as verify:
+            verify.return_value = True
+            cli.main(["stop", "config/basic"])
+
+    assert not verify.called
+
+
+def test_verify_data_loss_warns_if_loss():
+    cfg = MontaguConfig("config/basic")
+    f = io.StringIO()
+    with redirect_stdout(f):
+        with mock.patch("src.montagu_deploy.cli.prompt_yes_no") as prompt:
+            prompt.return_value = True
+            verify_data_loss(cfg)
+
+    assert prompt.called
+    assert "WARNING! PROBABLE IRREVERSIBLE DATA LOSS!" in f.getvalue()
+
+
+def test_verify_data_loss_throws_if_loss():
+    cfg = MontaguConfig("config/basic")
+    with mock.patch("src.montagu_deploy.cli.prompt_yes_no") as prompt:
+        prompt.return_value = False
+        with pytest.raises(Exception, match="Not continuing"):
+            verify_data_loss(cfg)
+
+
+def test_verify_data_prevents_unwanted_loss():
+    cfg = MontaguConfig("config/basic")
+    cfg.protect_data = True
+    msg = "Cannot remove volumes with this configuration"
+    with mock.patch("src.montagu_deploy.cli.prompt_yes_no"):
+        with pytest.raises(Exception, match=msg):
+            verify_data_loss(cfg)
+
+
+def test_prompt_is_quite_strict():
+    assert prompt_yes_no(lambda _: "yes")
+    assert not prompt_yes_no(lambda _: "no")
+    assert not prompt_yes_no(lambda _: "Yes")
+    assert not prompt_yes_no(lambda _: "Great idea!")
+    assert not prompt_yes_no(lambda _: "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,3 +136,13 @@ def test_prompt_is_quite_strict():
     assert not prompt_yes_no(lambda _: "Yes")
     assert not prompt_yes_no(lambda _: "Great idea!")
     assert not prompt_yes_no(lambda _: "")
+
+
+def test_bad_option_format():
+    with pytest.raises(Exception, match="Invalid option"):
+        cli.parse_args(["start", "config/basic", "--option=one:two"])
+
+
+def test_invalid_option_type():
+    with pytest.raises(Exception, match="Invalid value"):
+        cli.parse_args(["start", "config/basic", "--option=one={2}"])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,37 @@
+from unittest import mock
+
+import docker
+from constellation import docker_util
+
+from src.montagu_deploy import cli
+from src.montagu_deploy.config import MontaguConfig
+
+
+def test_start_stop_status():
+    path = "config/basic"
+    try:
+        # Start
+        res = cli.main(["start", path, "--pull"])
+        assert res
+
+        cl = docker.client.from_env()
+        containers = cl.containers.list()
+        assert len(containers) == 2
+        cfg = MontaguConfig(path)
+        assert docker_util.network_exists(cfg.network)
+
+        # Status
+        res = cli.main(["status", "config/basic"])
+        assert res
+
+        # Stop
+        with mock.patch("src.montagu_deploy.cli.prompt_yes_no") as prompt:
+            prompt.return_value = True
+            cli.main(["stop", path, "--kill", "--volumes", "--network"])
+            containers = cl.containers.list()
+            assert len(containers) == 0
+            assert not docker_util.network_exists(cfg.network)
+    finally:
+        with mock.patch("src.montagu_deploy.cli.prompt_yes_no") as prompt:
+            prompt.return_value = True
+            cli.main(["stop", path, "--kill", "--volumes", "--network"])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,6 +19,7 @@ def test_start_stop_status():
         assert len(containers) == 2
         cfg = MontaguConfig(path)
         assert docker_util.network_exists(cfg.network)
+        assert docker_util.volume_exists(cfg.volumes["db"])
 
         # Status
         res = cli.main(["status", "config/basic"])
@@ -31,6 +32,7 @@ def test_start_stop_status():
             containers = cl.containers.list()
             assert len(containers) == 0
             assert not docker_util.network_exists(cfg.network)
+            assert not docker_util.volume_exists(cfg.volumes["db"])
     finally:
         with mock.patch("src.montagu_deploy.cli.prompt_yes_no") as prompt:
             prompt.return_value = True


### PR DESCRIPTION
Adds the CLI and tests. It's complaining about code cov being 98% but the path it wants tested is impossible (user passes an argument that isn't one of `version`, `start`, `status` or `stop` and yet makes it past docopt parsing).