### PR TITLE
vimc-7181 add nginx metrics

### DIFF
--- a/config/basic/montagu.yml
+++ b/config/basic/montagu.yml
@@ -67,6 +67,10 @@ proxy:
   tag: vimc-7152
   port_http: 80
   port_https: 443
+  metrics:
+    repo: nginx
+    name: nginx-prometheus-exporter
+    tag: 0.10.0
 contrib:
   name: montagu-contrib-portal
   tag: master

--- a/config/complete/montagu.yml
+++ b/config/complete/montagu.yml
@@ -77,6 +77,10 @@ proxy:
   tag: master
   port_http: 80
   port_https: 443
+  metrics:
+    repo: nginx
+    name: nginx-prometheus-exporter
+    tag: 0.4.1
   ## This section describes how to get the certificate in.  We
   ## support two sources:
   ##

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "constellation>=1.0.1",
+  "constellation>=1.0.3",
   "docopt",
   "psycopg2"
 ]

--- a/src/montagu_deploy/__about__.py
+++ b/src/montagu_deploy/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Alex <alex.hill@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.1"
+__version__ = "0.0.3"

--- a/src/montagu_deploy/config.py
+++ b/src/montagu_deploy/config.py
@@ -64,6 +64,7 @@ class MontaguConfig:
             self.dhparam = config.config_string(dat, ["proxy", "ssl", "dhparam"])
         self.proxy_port_http = config.config_integer(dat, ["proxy", "port_http"])
         self.proxy_port_https = config.config_integer(dat, ["proxy", "port_https"])
+        self.proxy_metrics_ref = self.build_ref(dat["proxy"], "metrics")
 
         # Portals
         self.admin_ref = self.build_ref(dat, "admin")
@@ -75,6 +76,7 @@ class MontaguConfig:
             "db": "db",
             "api": "api",
             "proxy": "proxy",
+            "metrics": "proxy-metrics",
             "admin": "admin",
             "contrib": "contrib",
             "static": "static",
@@ -84,6 +86,7 @@ class MontaguConfig:
             "db": self.db_ref,
             "api": self.api_ref,
             "proxy": self.proxy_ref,
+            "metrics": self.proxy_metrics_ref,
             "admin": self.admin_ref,
             "contrib": self.contrib_ref,
             "static": self.static_ref,

--- a/src/montagu_deploy/config.py
+++ b/src/montagu_deploy/config.py
@@ -96,4 +96,8 @@ class MontaguConfig:
     def build_ref(self, dat, section):
         name = config.config_string(dat, [section, "name"])
         tag = config.config_string(dat, [section, "tag"])
-        return constellation.ImageReference(self.repo, name, tag)
+        if "repo" in dat[section]:
+            repo = config.config_string(dat, [section, "repo"])
+        else:
+            repo = self.repo
+        return constellation.ImageReference(repo, name, tag)

--- a/src/montagu_deploy/montagu_constellation.py
+++ b/src/montagu_deploy/montagu_constellation.py
@@ -208,9 +208,10 @@ def proxy_configure(container, cfg):
 def start_proxy_metrics(cfg):
     name = "{}-{}".format(cfg.container_prefix, cfg.containers["metrics"])
     proxy_name = cfg.containers["proxy"]
-    print("Starting {} ({})".format(cfg.containers["metrics"], str(cfg.proxy_metrics_ref)))
+    image = str(cfg.proxy_metrics_ref)
+    print("Starting {} ({})".format(cfg.containers["metrics"], image))
     docker.from_env().containers.run(
-        "nginx/nginx-prometheus-exporter:0.4.1",
+        image,
         restart_policy={"Name": "always"},
         ports={"9113/tcp": 9113},
         command=f'-nginx.scrape-uri "http://{proxy_name}/basic_status"',

--- a/src/montagu_deploy/montagu_constellation.py
+++ b/src/montagu_deploy/montagu_constellation.py
@@ -26,12 +26,20 @@ class MontaguConstellation:
 
     def start(self, **kwargs):
         self.obj.start(**kwargs)
+        # The proxy metrics container cannot be started via constellation, because
+        # it has to belong to the same network as the proxy as soon as it is started
+        # and constellation starts containers on the 'none' network. So we provide
+        # start/stop/status methods for the metrics container that mimic the
+        # constellation behaviour
+        start_proxy_metrics(self.cfg)
 
     def stop(self, **kwargs):
+        stop_proxy_metrics(self.cfg)
         self.obj.stop(**kwargs)
 
     def status(self):
         self.obj.status()
+        status_proxy_metrics(self.cfg)
 
 
 def admin_container(cfg):
@@ -195,3 +203,41 @@ def proxy_configure(container, cfg):
         docker_util.string_into_container(cfg.ssl_certificate, container, join(ssl_path, "certificate.pem"))
         docker_util.string_into_container(cfg.ssl_key, container, join(ssl_path, "ssl_key.pem"))
         docker_util.string_into_container(cfg.dhparam, container, join(ssl_path, "dhparam.pem"))
+
+
+def start_proxy_metrics(cfg):
+    name = "{}-{}".format(cfg.container_prefix, cfg.containers["metrics"])
+    proxy_name = cfg.containers["proxy"]
+    print("Starting {} ({})".format(cfg.containers["metrics"], str(cfg.proxy_metrics_ref)))
+    docker.from_env().containers.run(
+        "nginx/nginx-prometheus-exporter:0.4.1",
+        restart_policy={"Name": "always"},
+        ports={"9113/tcp": 9113},
+        command=f'-nginx.scrape-uri "http://{proxy_name}/basic_status"',
+        network=cfg.network,
+        name=name,
+        detach=True,
+    )
+
+
+def stop_proxy_metrics(cfg):
+    name = "{}-{}".format(cfg.container_prefix, cfg.containers["metrics"])
+    container = get_container(name)
+    if container:
+        print(f"Killing '{name}'")
+        container.remove(force=True)
+
+
+def status_proxy_metrics(cfg):
+    name = "{}-{}".format(cfg.container_prefix, cfg.containers["metrics"])
+    container = get_container(name)
+    status = container.status if container else "missing"
+    print("    - {} ({}): {}".format(cfg.containers["metrics"], name, status))
+
+
+def get_container(name):
+    client = docker.client.from_env()
+    try:
+        return client.containers.get(name)
+    except docker.errors.NotFound:
+        return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def test_parse_args():
 
 def test_version():
     res = cli.main(["--version"])
-    assert res == "0.0.1"
+    assert res == "0.0.3"
 
 
 def test_args_passed_to_start():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,21 +15,23 @@ def test_config_basic():
     assert cfg.volumes["static_logs"] == "static_logs"
     assert cfg.container_prefix == "montagu"
 
-    assert len(cfg.containers) == 6
+    assert len(cfg.containers) == 7
     assert cfg.containers["api"] == "api"
     assert cfg.containers["db"] == "db"
     assert cfg.containers["admin"] == "admin"
     assert cfg.containers["contrib"] == "contrib"
     assert cfg.containers["static"] == "static"
     assert cfg.containers["proxy"] == "proxy"
+    assert cfg.containers["metrics"] == "proxy-metrics"
 
-    assert len(cfg.images) == 7
+    assert len(cfg.images) == 8
     assert str(cfg.images["db"]) == "vimc/montagu-db:master"
     assert str(cfg.images["api"]) == "vimc/montagu-api:master"
     assert str(cfg.images["admin"]) == "vimc/montagu-admin-portal:master"
     assert str(cfg.images["contrib"]) == "vimc/montagu-contrib-portal:master"
     assert str(cfg.images["static"]) == "vimc/montagu-static:master"
     assert str(cfg.images["proxy"]) == "vimc/montagu-reverse-proxy:vimc-7152"
+    assert str(cfg.images["metrics"]) == "nginx/nginx-prometheus-exporter:0.10.0"
     assert str(cfg.images["db_migrate"]) == "vimc/montagu-migrate:master"
 
     assert cfg.protect_data is False

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -17,7 +17,7 @@ def test_start_and_stop():
 
     cl = docker.client.from_env()
     containers = cl.containers.list()
-    assert len(containers) == 6
+    assert len(containers) == 7
 
     assert docker_util.network_exists(cfg.network)
     assert docker_util.volume_exists(cfg.volumes["db"])
@@ -26,6 +26,7 @@ def test_start_and_stop():
     assert docker_util.container_exists("montagu-api")
     assert docker_util.container_exists("montagu-db")
     assert docker_util.container_exists("montagu-proxy")
+    assert docker_util.container_exists("montagu-proxy-metrics")
     assert docker_util.container_exists("montagu-admin")
     assert docker_util.container_exists("montagu-contrib")
 
@@ -122,6 +123,16 @@ def test_proxy_configured_ssl():
     assert cert == "cert"
     assert key == "k3y"
     assert param == "param"
+
+    obj.stop(kill=True)
+
+
+def test_metrics():
+    cfg = MontaguConfig("config/basic")
+    obj = MontaguConstellation(cfg)
+
+    obj.start()
+    http_get("http://localhost:9113/metrics")
 
     obj.stop(kill=True)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,7 @@ def test_start_stop_status():
 
         cl = docker.client.from_env()
         containers = cl.containers.list()
-        assert len(containers) == 6
+        assert len(containers) == 7
         cfg = MontaguConfig(path)
         assert docker_util.network_exists(cfg.network)
         assert docker_util.volume_exists(cfg.volumes["db"])


### PR DESCRIPTION
Adds the nginx metric exporter for Prometheus. 

Unfortunately:

`constellation` starts containers on the 'none' network, see https://github.com/reside-ic/constellation/blob/master/constellation/constellation.py#L123

Despite the issue being raised a couple of times (most recently https://github.com/nginxinc/nginx-prometheus-exporter/issues/336) the metrics exporter dies instantly on start if the url it's querying doesn't exist. So the container has to be brought up on the same network that the proxy container is running on.

This means that we can't just add the container to the constellation. We have to manage the start/stop and status reporting manually.

Deployed on UAT.

