### PR TITLE
Add support for certificates from Let's Encrypt.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,13 @@ jobs:
           docker pull vimc/montagu-db:master
           docker pull vimc/montagu-migrate:master
           docker pull vimc/montagu-reverse-proxy:master
-          docker pull vimc/montagu-reverse-proxy:vimc-7152
+          docker pull vimc/montagu-reverse-proxy:VIMC-7464-letsencrypt
           docker pull vimc/orderly-web-user-cli:master
           docker pull vimc/orderly-web:master
           docker pull vimc/orderly.server:master
           docker pull vimc/orderlyweb-migrate:master
           docker pull vimc/task-queue-worker:master
+          docker pull ghcr.io/letsencrypt/pebble:latest
       - name: Test
         env:
           VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
           docker pull vimc/montagu-db:master
           docker pull vimc/montagu-migrate:master
           docker pull vimc/montagu-reverse-proxy:master
-          docker pull vimc/montagu-reverse-proxy:VIMC-7464-letsencrypt
           docker pull vimc/orderly-web-user-cli:master
           docker pull vimc/orderly-web:master
           docker pull vimc/orderly.server:master

--- a/README.md
+++ b/README.md
@@ -16,28 +16,7 @@ pip install montagu-deploy
 ## Usage
 
 ```
-$ montagu --help
-Usage:
-  montagu --version
-  montagu start <path> [--extra=PATH] [--option=OPTION]... [--pull]
-  montagu status <path>
-  montagu stop <path> [--volumes] [--network] [--kill] [--force]
-    [--extra=PATH] [--option=OPTION]...
-
-Options:
-  --extra=PATH     Path, relative to <path>, of yml file of additional
-                   configuration
-  --option=OPTION  Additional configuration options, in the form key=value
-                   Use dots in key for hierarchical structure, e.g., a.b=value
-                   This argument may be repeated to provide multiple arguments
-  --pull           Pull images before starting
-  --volumes        Remove volumes (WARNING: irreversible data loss)
-  --network        Remove network
-  --kill           Kill the containers (faster, but possible db corruption)
-  --force          Force stop even if containers are corrupted and cannot
-                   signal their running configuration, or if config cannot be
-                   parsed. Use with extra and/or option to force stop with
-                   configuration options.
+$ montagu start <path>
 ```
 
 Here `<path>` is the path to a directory that contains a configuration file `montagu.yml`.

--- a/config/acme/diagnostic-reports.yml
+++ b/config/acme/diagnostic-reports.yml
@@ -1,0 +1,9 @@
+testGroup:
+  testDisease:
+    - report_name: diagnostic
+      assignee: a.hill
+      success_email:
+        recipients:
+          - minimal_modeller@example.com
+          - science@example.com
+        subject: "VIMC diagnostic report: {touchstone} - {group} - {disease}"

--- a/config/acme/montagu.yml
+++ b/config/acme/montagu.yml
@@ -14,7 +14,7 @@ repo: vimc
 network: montagu-network
 
 # Domain where this instance of Montagu will be deployed. E.g. science.montagu.dide.ic.uk
-hostname: localhost
+hostname: montagu.org
 
 ## Names of the docker volumes to use
 volumes:
@@ -78,6 +78,8 @@ proxy:
     tag: 1.3.0
   acme:
     email: admin@montagu.org
+    additional_domains:
+      - montagu-dev.org
 contrib:
   name: montagu-contrib-portal
   tag: master

--- a/config/acme/montagu.yml
+++ b/config/acme/montagu.yml
@@ -69,7 +69,7 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: VIMC-7464-letsencrypt
+  tag: master
   port_http: 80
   port_https: 443
   metrics:

--- a/config/acme/montagu.yml
+++ b/config/acme/montagu.yml
@@ -24,13 +24,13 @@ volumes:
   templates: template_volume
   guidance: guidance_volume
   mq: mq
+  acme-challenge: acme-challenge
+  certificates: certificates
+  certbot: certbot
 
 api:
   name: montagu-api
   tag: master
-  email:
-    password: "changeme"
-    flow_url: "fakeurl"
   admin:
     name: montagu-cli
     tag: master
@@ -38,7 +38,6 @@ db:
   name: montagu-db
   tag: master
   root_user: vimc
-  root_password: "changeme"
   migrate:
     name: montagu-migrate
     tag: master
@@ -55,12 +54,6 @@ db:
     readonly:
       password: "readonlypassword"
       permissions: readonly
-    barman:
-      password: "barmanpassword"
-      option: superuser
-    streaming_barman:
-      password: "streamingpassword"
-      option: replication
   protected_tables:
     - gavi_support_level
     - activity_type
@@ -76,24 +69,15 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: master
+  tag: VIMC-7464-letsencrypt
   port_http: 80
   port_https: 443
   metrics:
     repo: nginx
     name: nginx-prometheus-exporter
     tag: 1.3.0
-  ## This section describes how to get the certificate in.  We
-  ## support two sources:
-  ##
-  ## 1. self signed certificates - just leave this section blank
-  ##
-  ## 2. certificates from strings - include the strings directly in
-  ##    the keys here, or more likely use a VAULT:<path>:<key>
-  ##    string to extract them from the vault.
-  ssl:
-    key: "k3y"
-    certificate: "cert"
+  acme:
+    email: admin@montagu.org
 contrib:
   name: montagu-contrib-portal
   tag: master
@@ -113,27 +97,27 @@ flower:
 task_queue:
   name: task-queue-worker
   tag: master
-  youtrack_token: "faketoken"
-  servers:
-    montagu:
-      user: test.user@example.com
-      password: password
-    orderlyweb:
-      url: http://orderly-web-web:8888
-    youtrack:
-      token: faketoken
-    smtp:
-      host: smtp.cc.ic.ac.uk
-      port: 587
-      user: montagu
-      password: p@ssword
-      from: montagu-notifications@imperial.ac.uk
   tasks:
     diagnostic_reports:
-      use_additional_recipients: true
+      use_additional_recipients: false
       poll_seconds: 5
-      reports:
     archive_folder_contents:
       min_file_age_seconds: 3600
+  servers:
+    youtrack:
+      token: faketoken
+    orderlyweb:
+      url: http://orderly-web-web:8888
+    montagu:
+      user: montagu-task@imperial.ac.uk
+      password: password
+    smtp:
+      from: montagu-notifications@imperial.ac.uk
+# If fake_smtp_server config is provided, the task_queue will use this as its smtp server
+# Note this will override other config provided in the task_queue section above
+fake_smtp_server:
+  repo: reachfive
+  name: fake-smtp-server
+  tag: latest
 
 orderly_web_api_url: https://localhost/reports/api/v2

--- a/config/basic/montagu.yml
+++ b/config/basic/montagu.yml
@@ -66,7 +66,7 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: VIMC-7464-letsencrypt
+  tag: master
   port_http: 80
   port_https: 443
   metrics:

--- a/config/basic/montagu.yml
+++ b/config/basic/montagu.yml
@@ -66,7 +66,7 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: vimc-7152
+  tag: VIMC-7464-letsencrypt
   port_http: 80
   port_https: 443
   metrics:

--- a/config/ci/montagu.yml
+++ b/config/ci/montagu.yml
@@ -83,7 +83,7 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: VIMC-7464-letsencrypt
+  tag: master
   port_http: 80
   port_https: 443
   metrics:

--- a/config/ci/montagu.yml
+++ b/config/ci/montagu.yml
@@ -83,7 +83,7 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: vimc-7152
+  tag: VIMC-7464-letsencrypt
   port_http: 80
   port_https: 443
   metrics:

--- a/config/complete/montagu.yml
+++ b/config/complete/montagu.yml
@@ -76,7 +76,7 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: VIMC-7464-letsencrypt
+  tag: master
   port_http: 80
   port_https: 443
   metrics:

--- a/config/complete/montagu.yml
+++ b/config/complete/montagu.yml
@@ -76,7 +76,7 @@ db:
     - role_permission
 proxy:
   name: montagu-reverse-proxy
-  tag: master
+  tag: VIMC-7464-letsencrypt
   port_http: 80
   port_https: 443
   metrics:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ dependencies = [
   "pytest",
   "redis",
   "vault_dev",
-  "YTClient"
+  "YTClient",
+  "cryptography"
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/src/montagu_deploy/certbot.py
+++ b/src/montagu_deploy/certbot.py
@@ -29,7 +29,7 @@ def read_file(container, path, *, follow_links=False):
                 return tar.extractfile(os.path.basename(path)).read()
 
 
-def obtain_certificate(cfg, *, force_renewal=False, expand=False):
+def obtain_certificate(cfg, extra_args):
     docker_util.ensure_volume(cfg.volumes["certbot"])
     docker_util.ensure_volume(cfg.volumes["acme-challenge"])
 
@@ -47,15 +47,13 @@ def obtain_certificate(cfg, *, force_renewal=False, expand=False):
     for d in cfg.acme_additional_domains:
         command.append(f"--domain={d}")
 
-    if force_renewal:
-        command.append("--force-renewal")
-    if expand:
-        command.append("--expand")
     if cfg.acme_server:
         command.append(f"--server={cfg.acme_server}"),
     if cfg.acme_no_verify_ssl:
         command.append("--no-verify-ssl")
         environment["PYTHONWARNINGS"] = "ignore:Unverified HTTPS request"
+
+    command.extend(extra_args)
 
     image = "certbot/certbot"
     container = docker.from_env().containers.run(

--- a/src/montagu_deploy/certbot.py
+++ b/src/montagu_deploy/certbot.py
@@ -29,10 +29,11 @@ def read_file(container, path, *, follow_links=False):
                 return tar.extractfile(os.path.basename(path)).read()
 
 
-def obtain_certificate(cfg, *, force_renewal=False):
+def obtain_certificate(cfg, *, force_renewal=False, expand=False):
     docker_util.ensure_volume(cfg.volumes["certbot"])
     docker_util.ensure_volume(cfg.volumes["acme-challenge"])
 
+    environment = {}
     command = [
         "certonly",
         "--non-interactive",
@@ -46,10 +47,10 @@ def obtain_certificate(cfg, *, force_renewal=False):
     for d in cfg.acme_additional_domains:
         command.append(f"--domain={d}")
 
-    environment = {}
-
     if force_renewal:
         command.append("--force-renewal")
+    if expand:
+        command.append("--expand")
     if cfg.acme_server:
         command.append(f"--server={cfg.acme_server}"),
     if cfg.acme_no_verify_ssl:

--- a/src/montagu_deploy/certbot.py
+++ b/src/montagu_deploy/certbot.py
@@ -1,0 +1,87 @@
+# https://github.com/certbot/certbot/blob/v3.0.1/acme/examples/http01_example.py
+
+import os.path
+import sys
+import tarfile
+from tempfile import TemporaryFile
+
+import docker
+from constellation import docker_util
+
+# The Docker API uses Go's FileMode values. These are different from the
+# standard values, as found in eg. stat.S_IFLNK.
+# https://pkg.go.dev/io/fs#FileMode
+DOCKER_MODE_TYPE = 0x8F280000
+DOCKER_MODE_SYMLINK = 0x8000000
+
+
+def read_file(container, path, *, follow_links=False):
+    stream, status = container.get_archive(path)
+    if follow_links and (status["mode"] & DOCKER_MODE_TYPE) == DOCKER_MODE_SYMLINK:
+        return read_file(container, status["linkTarget"], follow_links=False)
+    else:
+        with TemporaryFile() as f:
+            for d in stream:
+                f.write(d)
+            f.seek(0)
+
+            with tarfile.open(fileobj=f) as tar:
+                return tar.extractfile(os.path.basename(path)).read()
+
+
+def obtain_certificate(cfg, *, force_renewal=False):
+    docker_util.ensure_volume(cfg.volumes["certbot"])
+    docker_util.ensure_volume(cfg.volumes["acme-challenge"])
+
+    command = [
+        "certonly",
+        "--non-interactive",
+        "--agree-tos",
+        "--webroot",
+        "--webroot-path=/var/www",
+        f"--email={cfg.acme_email}",
+        f"--domain={cfg.hostname}",
+    ]
+    environment = {}
+
+    if force_renewal:
+        command.append("--force-renewal")
+    if cfg.acme_server:
+        command.append(f"--server={cfg.acme_server}"),
+    if cfg.acme_no_verify_ssl:
+        command.append("--no-verify-ssl")
+        environment["PYTHONWARNINGS"] = "ignore:Unverified HTTPS request"
+
+    image = "certbot/certbot"
+    container = docker.from_env().containers.run(
+        image,
+        command=command,
+        detach=True,
+        volumes={
+            cfg.volumes["acme-challenge"]: {
+                "bind": "/var/www/.well-known/acme-challenge",
+                "mode": "rw",
+            },
+            cfg.volumes["certbot"]: {
+                "bind": "/etc/letsencrypt",
+                "mode": "rw",
+            },
+        },
+        network=cfg.network,
+        environment=environment,
+    )
+
+    try:
+        exit_status = container.wait()["StatusCode"]
+
+        sys.stderr.write(container.logs().decode("utf-8"))
+        if exit_status != 0:
+            raise docker.errors.ContainerError(container, exit_status, command, image, None)
+
+        cert = read_file(container, f"/etc/letsencrypt/live/{cfg.hostname}/fullchain.pem", follow_links=True)
+        key = read_file(container, f"/etc/letsencrypt/live/{cfg.hostname}/privkey.pem", follow_links=True)
+
+        return (cert, key)
+
+    finally:
+        container.remove()

--- a/src/montagu_deploy/certbot.py
+++ b/src/montagu_deploy/certbot.py
@@ -42,6 +42,10 @@ def obtain_certificate(cfg, *, force_renewal=False):
         f"--email={cfg.acme_email}",
         f"--domain={cfg.hostname}",
     ]
+
+    for d in cfg.acme_additional_domains:
+        command.append(f"--domain={d}")
+
     environment = {}
 
     if force_renewal:

--- a/src/montagu_deploy/cli.py
+++ b/src/montagu_deploy/cli.py
@@ -50,9 +50,7 @@ def main(argv=None):
         elif args.action == "stop":
             montagu_stop(obj, args, cfg)
         elif args.action == "renew-certificate":
-            montagu_renew_certificate(obj, cfg,
-                                      force_renewal=args.force_renewal,
-                                      expand=args.expand)
+            montagu_renew_certificate(obj, cfg, force_renewal=args.force_renewal, expand=args.expand)
         return True
 
 

--- a/src/montagu_deploy/config.py
+++ b/src/montagu_deploy/config.py
@@ -67,6 +67,7 @@ class MontaguConfig:
             self.acme_email = config.config_string(dat, ["proxy", "acme", "email"])
             self.acme_server = config.config_string(dat, ["proxy", "acme", "server"], is_optional=True)
             self.acme_no_verify_ssl = config.config_boolean(dat, ["proxy", "acme", "no_verify_ssl"], is_optional=True)
+            self.acme_additional_domains = config.config_list(dat, ["proxy", "acme", "additional_domains"], is_optional=True, default=[])
         else:
             self.ssl_mode = "self-signed"
 

--- a/src/montagu_deploy/config.py
+++ b/src/montagu_deploy/config.py
@@ -13,14 +13,7 @@ class MontaguConfig:
         self.vault = config.config_vault(dat, ["vault"])
         self.network = config.config_string(dat, ["network"])
         self.protect_data = config.config_boolean(dat, ["protect_data"])
-        self.volumes = {
-            "db": config.config_string(dat, ["volumes", "db"]),
-            "emails": config.config_string(dat, ["volumes", "emails"]),
-            "burden_estimates": config.config_string(dat, ["volumes", "burden_estimates"]),
-            "templates": config.config_string(dat, ["volumes", "templates"]),
-            "guidance": config.config_string(dat, ["volumes", "guidance"]),
-            "mq": config.config_string(dat, ["volumes", "mq"]),
-        }
+        self.volumes = config.config_dict(dat, ["volumes"])
 
         self.container_prefix = config.config_string(dat, ["container_prefix"])
         self.repo = config.config_string(dat, ["repo"])
@@ -58,14 +51,24 @@ class MontaguConfig:
 
         # Proxy
         self.proxy_ref = self.build_ref(dat, "proxy")
-        self.proxy_ssl_self_signed = "ssl" not in dat["proxy"]
-        if not self.proxy_ssl_self_signed:
-            self.ssl_certificate = config.config_string(dat, ["proxy", "ssl", "certificate"])
-            self.ssl_key = config.config_string(dat, ["proxy", "ssl", "key"])
-            self.dhparam = config.config_string(dat, ["proxy", "ssl", "dhparam"])
         self.proxy_port_http = config.config_integer(dat, ["proxy", "port_http"])
         self.proxy_port_https = config.config_integer(dat, ["proxy", "port_https"])
         self.proxy_metrics_ref = self.build_ref(dat["proxy"], "metrics")
+
+        if "ssl" in dat["proxy"] and "acme" in dat["proxy"]:
+            msg = "Cannot specify both ssl and acme options in proxy options."
+            raise Exception(msg)
+        if "ssl" in dat["proxy"]:
+            self.ssl_mode = "static"
+            self.ssl_certificate = config.config_string(dat, ["proxy", "ssl", "certificate"])
+            self.ssl_key = config.config_string(dat, ["proxy", "ssl", "key"])
+        elif "acme" in dat["proxy"]:
+            self.ssl_mode = "acme"
+            self.acme_email = config.config_string(dat, ["proxy", "acme", "email"])
+            self.acme_server = config.config_string(dat, ["proxy", "acme", "server"], is_optional=True)
+            self.acme_no_verify_ssl = config.config_boolean(dat, ["proxy", "acme", "no_verify_ssl"], is_optional=True)
+        else:
+            self.ssl_mode = "self-signed"
 
         # Portals
         self.admin_ref = self.build_ref(dat, "admin")

--- a/src/montagu_deploy/config.py
+++ b/src/montagu_deploy/config.py
@@ -67,7 +67,9 @@ class MontaguConfig:
             self.acme_email = config.config_string(dat, ["proxy", "acme", "email"])
             self.acme_server = config.config_string(dat, ["proxy", "acme", "server"], is_optional=True)
             self.acme_no_verify_ssl = config.config_boolean(dat, ["proxy", "acme", "no_verify_ssl"], is_optional=True)
-            self.acme_additional_domains = config.config_list(dat, ["proxy", "acme", "additional_domains"], is_optional=True, default=[])
+            self.acme_additional_domains = config.config_list(
+                dat, ["proxy", "acme", "additional_domains"], is_optional=True, default=[]
+            )
         else:
             self.ssl_mode = "self-signed"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import io
+import re
 from contextlib import redirect_stdout
 from unittest import mock
 
@@ -44,9 +45,10 @@ def test_parse_args():
     assert args.version is True
 
 
-def test_version():
-    res = cli.main(["--version"])
-    assert res == "0.0.5"
+def test_version(capsys):
+    cli.main(["--version"])
+    out, err = capsys.readouterr()
+    assert re.match(r"\d+\.\d+\.\d+", out)
 
 
 def test_args_passed_to_start():
@@ -79,6 +81,16 @@ def test_args_passed_to_stop():
     assert f.call_args[0][1].kill is False
     assert f.call_args[0][1].network is True
     assert f.call_args[0][1].volumes is True
+
+
+def test_can_parse_extra_certbot_args():
+    res = cli.parse_args(["renew-certificate", "config/basic", "--", "--force-renewal"])
+    assert res[0] == "config/basic"
+    assert res[1] is None
+    assert res[2] == []
+    args = res[3]
+    assert args.action == "renew-certificate"
+    assert args.extra_args == ["--force-renewal"]
 
 
 def test_verify_data_loss_called():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,7 +84,7 @@ def test_config_ssl():
 def test_config_acme():
     cfg = MontaguConfig("config/acme")
     assert cfg.ssl_mode == "acme"
-    assert cfg.acme_email == "admin@montagu.com"
+    assert cfg.acme_email == "admin@montagu.org"
     assert cfg.acme_server is None
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ def test_config_basic():
     assert str(cfg.images["admin"]) == "vimc/montagu-admin-portal:master"
     assert str(cfg.images["api_admin"]) == "vimc/montagu-cli:master"
     assert str(cfg.images["contrib"]) == "vimc/montagu-contrib-portal:master"
-    assert str(cfg.images["proxy"]) == "vimc/montagu-reverse-proxy:VIMC-7464-letsencrypt"
+    assert str(cfg.images["proxy"]) == "vimc/montagu-reverse-proxy:master"
     assert str(cfg.images["mq"]) == "docker.io/redis:latest"
     assert str(cfg.images["flower"]) == "mher/flower:0.9.5"
     assert str(cfg.images["task_queue"]) == "vimc/task-queue-worker:master"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ def test_config_basic():
     assert str(cfg.images["admin"]) == "vimc/montagu-admin-portal:master"
     assert str(cfg.images["api_admin"]) == "vimc/montagu-cli:master"
     assert str(cfg.images["contrib"]) == "vimc/montagu-contrib-portal:master"
-    assert str(cfg.images["proxy"]) == "vimc/montagu-reverse-proxy:vimc-7152"
+    assert str(cfg.images["proxy"]) == "vimc/montagu-reverse-proxy:VIMC-7464-letsencrypt"
     assert str(cfg.images["mq"]) == "docker.io/redis:latest"
     assert str(cfg.images["flower"]) == "mher/flower:0.9.5"
     assert str(cfg.images["task_queue"]) == "vimc/task-queue-worker:master"
@@ -46,7 +46,7 @@ def test_config_basic():
     assert cfg.flower_port == 5555
 
     assert cfg.protect_data is False
-    assert cfg.proxy_ssl_self_signed is True
+    assert cfg.ssl_mode == "self-signed"
 
     assert cfg.db_root_user == "vimc"
     assert len(cfg.db_root_password) == 50
@@ -76,10 +76,16 @@ def test_config_email():
 
 def test_config_ssl():
     cfg = MontaguConfig("config/complete")
-    assert cfg.proxy_ssl_self_signed is False
+    assert cfg.ssl_mode == "static"
     assert cfg.ssl_certificate == "cert"
     assert cfg.ssl_key == "k3y"
-    assert cfg.dhparam == "param"
+
+
+def test_config_acme():
+    cfg = MontaguConfig("config/acme")
+    assert cfg.ssl_mode == "acme"
+    assert cfg.acme_email == "admin@montagu.com"
+    assert cfg.acme_server is None
 
 
 def test_config_generates_root_db_password():

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -90,10 +90,8 @@ def test_proxy_configured_self_signed():
         api = get_container(cfg, "proxy")
         cert = docker_util.string_from_container(api, "/etc/montagu/proxy/certificate.pem")
         key = docker_util.string_from_container(api, "/etc/montagu/proxy/ssl_key.pem")
-        param = docker_util.string_from_container(api, "/etc/montagu/proxy/dhparam.pem")
         assert cert is not None
         assert key is not None
-        assert param is not None
 
         res = http_get("https://localhost")
         assert "Montagu" in res
@@ -136,10 +134,8 @@ def test_proxy_configured_ssl():
         api = get_container(cfg, "proxy")
         cert = docker_util.string_from_container(api, "/etc/montagu/proxy/certificate.pem")
         key = docker_util.string_from_container(api, "/etc/montagu/proxy/ssl_key.pem")
-        param = docker_util.string_from_container(api, "/etc/montagu/proxy/dhparam.pem")
         assert cert == "cert"
         assert key == "k3y"
-        assert param == "param"
 
     finally:
         obj.stop(kill=True, remove_volumes=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -120,7 +120,7 @@ def test_acme_certificate():
 
     try:
         options = [
-            f"--option=proxy.acme.server=https://pebble/dir",
+            "--option=proxy.acme.server=https://pebble/dir",
             "--option=proxy.acme.no_verify_ssl=true",
         ]
 
@@ -134,7 +134,7 @@ def test_acme_certificate():
         # We set this up by adding a custom /etc/hosts in the pebble container pointing to the
         # right IP address.
         container = docker.from_env().containers.get("montagu-proxy")
-        ip = container.attrs['NetworkSettings']['Networks'][network]['IPAddress']
+        ip = container.attrs["NetworkSettings"]["Networks"][network]["IPAddress"]
         hostnames = {
             "montagu.org": ip,
             "montagu-dev.org": ip,
@@ -167,8 +167,8 @@ def test_acme_certificate():
             assert "CN=Pebble Intermediate CA" in cert.issuer.rfc4514_string()
             san = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
             assert set(san.value.get_values_for_type(x509.DNSName)) == {
-                'montagu.org',
-                'montagu-dev.org',
+                "montagu.org",
+                "montagu-dev.org",
             }
 
             # When restarting the server, the certificate we got from ACME is

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,8 +26,7 @@ def test_start_stop_status():
     path = "config/basic"
     try:
         # Start
-        res = cli.main(["start", path])
-        assert res
+        cli.main(["start", path])
 
         cl = docker.client.from_env()
         containers = cl.containers.list()
@@ -38,8 +37,7 @@ def test_start_stop_status():
         assert docker_util.volume_exists(cfg.volumes["db"])
 
         # Status
-        res = cli.main(["status", "config/basic"])
-        assert res
+        cli.main(["status", "config/basic"])
 
         # Stop
         with mock.patch("src.montagu_deploy.cli.prompt_yes_no") as prompt:
@@ -124,8 +122,7 @@ def test_acme_certificate():
             "--option=proxy.acme.no_verify_ssl=true",
         ]
 
-        res = cli.main(["start", path, *options])
-        assert res
+        cli.main(["start", path, *options])
 
         # wait for nginx to be ready
         http_get("https://localhost")
@@ -151,8 +148,7 @@ def test_acme_certificate():
             # Renew the certificate using ACME. Confirm that it worked by
             # looking at the issuer's CN. It can take some time for nginx to
             # reload, so loop until the certificate has changed.
-            res = cli.main(["renew-certificate", path, *options])
-            assert res
+            cli.main(["renew-certificate", path, *options])
 
             for _ in range(5):
                 cert_pem = ssl.get_server_certificate(("localhost", 443))
@@ -174,10 +170,8 @@ def test_acme_certificate():
             # When restarting the server, the certificate we got from ACME is
             # carried over and is immediately available, no need to issue it
             # again.
-            res = cli.main(["stop", path, "--kill"])
-            assert res
-            res = cli.main(["start", path, *options])
-            assert res
+            cli.main(["stop", path, "--kill"])
+            cli.main(["start", path, *options])
 
             cert_pem = ssl.get_server_certificate(("localhost", 443))
             cert = x509.load_pem_x509_certificate(cert_pem.encode("ascii"))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,6 @@
 import os
 import ssl
 import time
-from cryptography.hazmat.primitives import hashes
 from unittest import mock
 
 import celery
@@ -12,6 +11,7 @@ import requests
 import vault_dev
 from constellation import docker_util
 from cryptography import x509
+from cryptography.hazmat.primitives import hashes
 from YTClient.YTClient import YTClient
 from YTClient.YTDataClasses import Command
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,5 +62,5 @@ def run_pebble(network):
         container.start()
         container.reload()
 
-        url = f"https://{container.attrs["NetworkSettings"]["Networks"][network]["IPAddress"]}/dir"
+        url = f"https://{container.attrs['NetworkSettings']['Networks'][network]['IPAddress']}/dir"
         yield url

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,9 +56,7 @@ def run_pebble(**kwargs):
     }
 
     with create_container(
-        "ghcr.io/letsencrypt/pebble:latest", command=["-config", "/config.json"],
-        environment=env,
-        **kwargs
+        "ghcr.io/letsencrypt/pebble:latest", command=["-config", "/config.json"], environment=env, **kwargs
     ) as container:
         docker_util.string_into_container(json.dumps(config), container, "/config.json")
         container.start()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,7 +39,7 @@ def create_container(image, **kwargs):
 
 # Run the Pebble ACME server.
 @contextmanager
-def run_pebble(network):
+def run_pebble(**kwargs):
     env = {
         "PEBBLE_WFE_NONCEREJECT": 0,
         "PEBBLE_VA_NOSLEEP": 1,
@@ -56,11 +56,10 @@ def run_pebble(network):
     }
 
     with create_container(
-        "ghcr.io/letsencrypt/pebble:latest", command=["-config", "/config.json"], environment=env, network=network
+        "ghcr.io/letsencrypt/pebble:latest", command=["-config", "/config.json"],
+        environment=env,
+        **kwargs
     ) as container:
         docker_util.string_into_container(json.dumps(config), container, "/config.json")
         container.start()
-        container.reload()
-
-        url = f"https://{container.attrs['NetworkSettings']['Networks'][network]['IPAddress']}/dir"
-        yield url
+        yield


### PR DESCRIPTION
This adds a new configuration option named `acme` and a new sub-command `montagu renew-certificate`. Using these will fetch a certificate from Let's Encrypt (or another ACME provider), inject it into the proxy container and finally reload nginx. The host machine needs to be configured to run the `renew-certificate` on a regular basis, using, for example, crontab or systemd timers.

The ACME protocol is handled by running certbot as its own short-lived container. Alternatives could have been a long-running container running a cron-like daemon, installing certbot inside the nginx container and using `docker exec` to run it, installing and running certbot directly on the host, using a Python implementation of the ACME protocol directly inside the montagu tool process.

The certbot container shares a volume with nginx to host the acme-challenge files on port 80. To allow nginx to start and serve these files before we have any certificate at all, the proxy generates a self-signed certificate on startup if none exist yet. This certificate would be replaced on the first renewal.

See vimc/montagu-proxy#87 for the proxy side of this, mapping the `/.well-known/acme-challenge` path to a directory on the file system.

While we support alternative ACME servers, in production we will probably stick to the default which uses Let's Encrypt. The configuration option makes it easier to trial the process using servers that aren't exposed publically, using a miniature ACME server such as [pebble][pebble]

In the future the ACME configuration block may be extended to support DNS challenges instead, allowing us to use this even on internal-only services. If and when this happens, we won't even need nginx to host acme-challenges and may be able to remove the need for the transient self-signed certificates.

Once we get more experience with this, we may also want to move some of this functionality into constellation, allowing it to be re-used in other projects.

[pebble]: https://github.com/letsencrypt/pebble