### PR TITLE
mrc-6706 Expose packit metrics port from proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 dist
 .coverage
 coverage.xml
+.montagu_identity

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ pip install montagu-deploy
 ## Usage
 
 ```
-$ montagu start <path>
+$ montagu configure <path>
+$ montagu start --pull
 ```
 
 Here `<path>` is the path to a directory that contains a configuration file `montagu.yml`.

--- a/src/montagu_deploy/__about__.py
+++ b/src/montagu_deploy/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Alex <alex.hill@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/src/montagu_deploy/config.py
+++ b/src/montagu_deploy/config.py
@@ -53,6 +53,7 @@ class MontaguConfig:
         self.proxy_ref = self.build_ref(dat, "proxy")
         self.proxy_port_http = config.config_integer(dat, ["proxy", "port_http"])
         self.proxy_port_https = config.config_integer(dat, ["proxy", "port_https"])
+        self.proxy_port_metrics = config.config_integer(dat, ["proxy", "port_metrics"], is_optional=True, default=9000)
         self.proxy_metrics_ref = self.build_ref(dat["proxy"], "metrics")
 
         if "ssl" in dat["proxy"] and "acme" in dat["proxy"]:

--- a/src/montagu_deploy/montagu_constellation.py
+++ b/src/montagu_deploy/montagu_constellation.py
@@ -208,7 +208,7 @@ def inject_api_config(container, cfg):
 
 def proxy_container(cfg):
     name = cfg.containers["proxy"]
-    proxy_ports = [cfg.proxy_port_http, cfg.proxy_port_https]
+    proxy_ports = [cfg.proxy_port_http, cfg.proxy_port_https, cfg.proxy_port_metrics]
 
     mounts = []
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,7 +59,7 @@ def test_config_basic():
     assert len(cfg.db_protected_tables) == 12
     assert cfg.db_protected_tables[0] == "gavi_support_level"
 
-    assert cfg.proxy_port_metrics  == 9000
+    assert cfg.proxy_port_metrics == 9000
 
 
 def test_config_email():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,6 +59,8 @@ def test_config_basic():
     assert len(cfg.db_protected_tables) == 12
     assert cfg.db_protected_tables[0] == "gavi_support_level"
 
+    assert cfg.proxy_port_metrics  == 9000
+
 
 def test_config_email():
     cfg = MontaguConfig("config/basic")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -119,6 +119,8 @@ def test_metrics_endpoints():
         packit.start(pull_images=True)
         cli.main(["start", "--name", path])
 
+        wait_for_packit_api()
+
         assert "jvm_info" in http_get("http://localhost:9000/metrics/packit-api")
         assert "http_requests_duration_seconds_bucket" in http_get("http://localhost:9000/metrics/outpack_server")
     finally:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -113,16 +113,11 @@ def test_task_queue():
 def test_metrics_endpoints():
     packit_config_path = "tests"
     path = "config/basic"
-    cfg = MontaguConfig(path)
     packit_config = PackitConfig(packit_config_path)
     try:
         packit = PackitConstellation(packit_config)
         packit.start(pull_images=True)
         cli.main(["start", "--name", path])
-
-        # wait for all containers to be ready
-        http_get("https://localhost/api/v1")
-        wait_for_packit_api()
 
         assert "jvm_info" in http_get("http://localhost:9000/metrics/packit-api")
         assert "http_requests_duration_seconds_bucket" in http_get("http://localhost:9000/metrics/outpack_server")


### PR DESCRIPTION
Ensure the port used by montagu proxy to provide packit and outpack server metrics is exposed to the host. 